### PR TITLE
fix: reset page to null when changing table filters

### DIFF
--- a/src/components/View/DeviceTransmissions.js
+++ b/src/components/View/DeviceTransmissions.js
@@ -55,6 +55,11 @@ const DeviceTransmissions = props => {
         });
     };
 
+    const updateTableFilters = parameters => {
+        parameters.page = null;
+        updateQueryParameters(parameters);
+    };
+
     const { page, pageSize, ...filters } = queryParameters;
 
     return (
@@ -129,7 +134,7 @@ const DeviceTransmissions = props => {
                                 },
                             ]}
                             filters={filters}
-                            updateFilters={updateQueryParameters}
+                            updateFilters={updateTableFilters}
                         />
                         <div className="pagination-footer">
                             <Select


### PR DESCRIPTION
Before

![oopBugfixBefore](https://user-images.githubusercontent.com/51908975/65947579-7ee4d580-e430-11e9-92e6-5574560d94f9.gif)

After

![oopBugfixAfter](https://user-images.githubusercontent.com/51908975/65947582-7f7d6c00-e430-11e9-970a-57906800e257.gif)
