### PR TITLE
feat: showing link to "/devices" while loading secondary navigation

### DIFF
--- a/src/components/Universal/DataProvider.js
+++ b/src/components/Universal/DataProvider.js
@@ -37,7 +37,7 @@ const DataProvider = props => {
             );
         }
     } else {
-        return <Spinner />;
+        return props.loadingFallback ? props.loadingFallback : <Spinner />;
     }
 };
 

--- a/src/components/View/SideNavigation.js
+++ b/src/components/View/SideNavigation.js
@@ -95,6 +95,13 @@ const SideNavigation = props => {
                         isActive={pathMatch("/devices")}
                     />
                 }
+                loadingFallback={
+                    <NavigationItem
+                        path="/devices"
+                        pathName="Devices"
+                        isActive={pathMatch("/devices")}
+                    />
+                }
             />
         );
     };


### PR DESCRIPTION
Before (slightly slow-mo):
![oopRefresh](https://user-images.githubusercontent.com/51908975/67500314-660bc080-f67a-11e9-94b5-dcc7dac42ecb.gif)

After:
![oopRefresh2](https://user-images.githubusercontent.com/51908975/67500323-699f4780-f67a-11e9-91fb-8475e8f0f17b.gif)
