### PR TITLE
fix: click to select/deselect no longer applies to whole row

### DIFF
--- a/src/components/Universal/Table.js
+++ b/src/components/Universal/Table.js
@@ -21,11 +21,6 @@ const Table = props => {
                         return (
                             <StyledRow
                                 key={index}
-                                onClick={() => {
-                                    if (props.onRowClick) {
-                                        props.onRowClick(row);
-                                    }
-                                }}
                                 className={
                                     props.rowClassName
                                         ? props.rowClassName(row)
@@ -44,6 +39,19 @@ const Table = props => {
                                         return (
                                             <CustomWidthCell
                                                 key={`table-cell-${index}-${column.id}`}
+                                                className={`${
+                                                    column.id === "action"
+                                                        ? "action-column"
+                                                        : ""
+                                                }`}
+                                                onClick={() => {
+                                                    if (props.onRowClick) {
+                                                        props.onRowClick(
+                                                            row,
+                                                            column.id,
+                                                        );
+                                                    }
+                                                }}
                                             >
                                                 {props.mapFunction(
                                                     column.id,
@@ -62,6 +70,14 @@ const Table = props => {
                                         return (
                                             <StyledCell
                                                 key={`table-cell-${index}-${column.id}`}
+                                                onClick={() => {
+                                                    if (props.onRowClick) {
+                                                        props.onRowClick(
+                                                            row,
+                                                            column.id,
+                                                        );
+                                                    }
+                                                }}
                                             >
                                                 {props.mapFunction(
                                                     column.id,

--- a/src/components/View/Device.js
+++ b/src/components/View/Device.js
@@ -693,8 +693,11 @@ const Device = props => {
                                                 }}
                                                 trueText="Selected"
                                                 falseText="Not selected"
-                                                onRowClick={tempr => {
-                                                    if (!loading) {
+                                                onRowClick={(tempr, column) => {
+                                                    if (
+                                                        column !== "action" &&
+                                                        !loading
+                                                    ) {
                                                         return toggleDeviceTempr(
                                                             tempr,
                                                         );

--- a/src/components/View/Tempr.js
+++ b/src/components/View/Tempr.js
@@ -427,8 +427,8 @@ const Tempr = props => {
                     }}
                     trueText="Selected"
                     falseText="Not selected"
-                    onRowClick={device => {
-                        if (!deviceTemprLoading) {
+                    onRowClick={(device, column) => {
+                        if (column !== "action" && !deviceTemprLoading) {
                             return toggleDeviceTempr(device);
                         }
                     }}

--- a/src/styles/layouts/_device_temprs.scss
+++ b/src/styles/layouts/_device_temprs.scss
@@ -1,8 +1,16 @@
 .device-tempr {
     cursor: pointer;
 
+    div {
+        &.action-column {
+            cursor: auto;
+        }
+    }
+
     &.selected {
-        background-color: $oop-teal;
+        div {
+            font-weight: bolder;
+        }
     }
 }
 


### PR DESCRIPTION
Device tempr 
- clicking on the "open device/tempr in new tab" button no longer toggles device tempr association
- made text bolder for selected items